### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,23 @@ language: php
 matrix:
   include:
     - name: '[REQUIRE_CHECK] With Locked Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: require=1
     - name: '[REQUIRE_CHECK] With Lowest Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: require=1 dependencies=lowest
     - name: '[REQUIRE_CHECK] With Highest Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: require=1 dependencies=highest
 
     - name: '[CS] PHP 7.4 With Locked Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: cs=1
     - name: '[CS] PHP 7.4 With Lowest Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: cs=1 dependencies=lowest
     - name: '[CS] PHP 7.4 With Highest Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: cs=1 dependencies=highest
     - name: '[CS] PHP Nightly With Locked Dependencies'
       php: nightly
@@ -34,13 +34,13 @@ matrix:
       env: cs=1 dependencies=highest
 
     - name: '[UNIT] PHP 7.4 With Locked Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: unit=1
     - name: '[UNIT] PHP 7.4 With Lowest Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: dependencies=lowest unit=1
     - name: '[UNIT] PHP 7.4 With Highest Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: dependencies=highest unit=1
     - name: '[UNIT] PHP Nightly With Locked Dependencies'
       php: nightly
@@ -53,13 +53,13 @@ matrix:
       env: dependencies=lowest unit=1
 
     - name: '[INTEGRATION] PHP 7.4 With Locked Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: integration=1
     - name: '[INTEGRATION] PHP 7.4 With Lowest Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: dependencies=lowest integration=1
     - name: '[INTEGRATION] PHP 7.4 With Highest Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: dependencies=highest integration=1
     - name: '[INTEGRATION] PHP Nightly With Locked Dependencies'
       php: nightly
@@ -72,13 +72,13 @@ matrix:
       env: dependencies=lowest integration=1
 
     - name: '[INFECTION] PHP 7.4 With Locked Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: infection=1
     - name: '[INFECTION] PHP 7.4 With Lowest Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: dependencies=lowest infection=1
     - name: '[INFECTION] PHP 7.4 With Highest Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: dependencies=highest infection=1
     - name: '[INFECTION] PHP Nightly With Locked Dependencies'
       php: nightly
@@ -91,13 +91,13 @@ matrix:
       env: dependencies=lowest infection=1
   allow_failures:
     - name: '[CS] PHP 7.4 With Locked Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: cs=1
     - name: '[CS] PHP 7.4 With Lowest Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: cs=1 dependencies=lowest
     - name: '[CS] PHP 7.4 With Highest Dependencies'
-      php: '7.4snapshot'
+      php: '7.4'
       env: cs=1 dependencies=highest
     - name: '[CS] PHP Nightly With Locked Dependencies'
       php: nightly

--- a/tests/Unit/Http/Exception/NetworkErrorTest.php
+++ b/tests/Unit/Http/Exception/NetworkErrorTest.php
@@ -10,7 +10,7 @@ final class NetworkErrorTest extends TestCase
 {
     private Request $request;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->request = new Request('https://example.com');
     }

--- a/tests/Unit/Http/ServerAddressTest.php
+++ b/tests/Unit/Http/ServerAddressTest.php
@@ -9,7 +9,7 @@ final class ServerAddressTest extends TestCase
 {
     private ServerAddress $serverAddress;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->serverAddress = new ServerAddress('0.0.0.0', 80);
     }

--- a/tests/Unit/Http/WebHookTest.php
+++ b/tests/Unit/Http/WebHookTest.php
@@ -15,7 +15,7 @@ final class WebHookTest extends TestCase
 {
     private WebHook $webHook;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->webHook = new WebHook('GET', '/endpoint', $this->createMock(WebHookListener::class));
     }

--- a/tests/Unit/Logger/LoggerTest.php
+++ b/tests/Unit/Logger/LoggerTest.php
@@ -15,7 +15,7 @@ final class LoggerTest extends TestCase
 
     private Logger $logger;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->psrLogger = $this->createMock(LoggerInterface::class);
 

--- a/tests/Unit/ManagerTest.php
+++ b/tests/Unit/ManagerTest.php
@@ -17,7 +17,7 @@ final class ManagerTest extends TestCase
 
     private Manager $manager;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->psrLogger = $this->createMock(LoggerInterface::class);
 

--- a/tests/Unit/Message/Node/AttributeTest.php
+++ b/tests/Unit/Message/Node/AttributeTest.php
@@ -9,7 +9,7 @@ final class AttributeTest extends TestCase
 {
     private Attribute $attribute;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->attribute = new Attribute('name', 'value');
     }

--- a/tests/Unit/Message/Node/ListTypeTest.php
+++ b/tests/Unit/Message/Node/ListTypeTest.php
@@ -14,7 +14,7 @@ final class ListTypeTest extends TestCase
 {
     private ListType $list;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->list = new UnorderedList();
     }

--- a/tests/Unit/Message/Node/MentionTest.php
+++ b/tests/Unit/Message/Node/MentionTest.php
@@ -9,7 +9,7 @@ final class MentionTest extends TestCase
 {
     private Mention $mention;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->mention = new Mention('stackoverflow', 'peehaa');
     }

--- a/tests/Unit/Message/Node/MessageTest.php
+++ b/tests/Unit/Message/Node/MessageTest.php
@@ -9,7 +9,7 @@ final class MessageTest extends TestCase
 {
     private Message $mention;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->mention = new Message();
     }

--- a/tests/Unit/Message/Node/OrderedListTest.php
+++ b/tests/Unit/Message/Node/OrderedListTest.php
@@ -10,7 +10,7 @@ final class OrderedListTest extends TestCase
 {
     private OrderedList $orderedList;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->orderedList = new OrderedList();
     }

--- a/tests/Unit/Message/Node/ParserTest.php
+++ b/tests/Unit/Message/Node/ParserTest.php
@@ -22,7 +22,7 @@ final class ParserTest extends TestCase
 {
     private Parser $parser;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->parser = new Parser();
     }

--- a/tests/Unit/Message/Node/UnorderedListTest.php
+++ b/tests/Unit/Message/Node/UnorderedListTest.php
@@ -10,7 +10,7 @@ final class UnorderedListTest extends TestCase
 {
     private UnorderedList $unorderedList;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->unorderedList = new UnorderedList();
     }

--- a/tests/Unit/Message/Node/UrlTest.php
+++ b/tests/Unit/Message/Node/UrlTest.php
@@ -9,7 +9,7 @@ final class UrlTest extends TestCase
 {
     private Url $url;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->url = new Url('https://example.com');
     }

--- a/tests/Unit/Storage/KeyValue/FileSystemTest.php
+++ b/tests/Unit/Storage/KeyValue/FileSystemTest.php
@@ -13,14 +13,14 @@ final class FileSystemTest extends TestCase
 
     private FileSystem $storage;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->originalData = file_get_contents(TEST_DATA_DIR . '/Storage/keyvalue-filesystem.json');
 
         $this->storage = new FileSystem(TEST_DATA_DIR . '/Storage/keyvalue-filesystem.json');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         file_put_contents(TEST_DATA_DIR . '/Storage/keyvalue-filesystem.json', $this->originalData);
     }


### PR DESCRIPTION
# Changed log
- Using the `php-7.4` version because it's available on Travis CI build now.
- According to the [PHPUnit fixtures](https://phpunit.readthedocs.io/en/8.3/fixtures.html?highlight=fixtures), these `setUp` and `tearDown` methods should be `protected`, not `public`.